### PR TITLE
Update docker-compose install command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,19 @@ Alternatively, simply perform the following steps：
 * Install docker-compose
 
    ```sh
-   sudo apt-get install docker-compose
+   To download and install Compose standalone, run:
+
+     curl -SL https://github.com/docker/compose/releases/download/v2.15.1/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+
+    Apply executable permissions to the standalone binary in the target path for the installation.
+    Test and execute compose commands using docker-compose.
+
+    Note
+
+    If the command docker-compose fails after installation, check your path. You can also create a symbolic link to /usr/bin or any other directory in your path. For example:
+
+ sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+
    ```
 * Pull carla image and run
   

--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ Alternatively, simply perform the following steps：
 
     Note
 
-    If the command docker-compose fails after installation, check your path. You can also create a symbolic link to /usr/bin or any other directory in your path. For example:
+    If the command docker-compose fails after installation, check your path. You can also create a symbolic link to /usr/bin or any other directory in your path. For example: sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 
- sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+ 
 
    ```
 * Pull carla image and run


### PR DESCRIPTION
The earlier command  "**_sudo apt-get install docker-compose_**"  installs older version of docker compose which creates **runtime** **error.** The new command installs the latest docker compose version which is compatible with the current version,without giving any runtime error.
![Screenshot from 2023-01-06 14-08-30](https://user-images.githubusercontent.com/98169680/211751071-940696b0-d7ca-464e-93d8-3dc5438c9a02.png)
